### PR TITLE
create see recently played link on media player

### DIFF
--- a/src/components/MediaPlayer.jsx
+++ b/src/components/MediaPlayer.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react'
+import { Link } from 'gatsby'
 import play from '../images/play.svg'
 import pause from '../images/pause.svg'
 import volumeSymbol from '../images/volume.svg'
@@ -95,6 +96,11 @@ export default function MediaPlayer() {
             <div id="radioco_song"></div>
             {/* <div className="artist">Artist Playing</div> */}
           </div>
+        </div>
+        <div className="player-history">
+          <Link to="/history" activeClassName="active">
+            see recently played &#62;
+          </Link>
         </div>
       </div>
       <div className="controls">

--- a/src/scss/_player.scss
+++ b/src/scss/_player.scss
@@ -39,6 +39,37 @@
     font-weight: 400;
   }
 
+  .player-history {
+    position: absolute;
+    display: flex;
+    margin: 141.59px 16px 14.56px 24.97px;
+
+    &:hover {
+      transform: scale(1.02);
+    }
+    
+    :first-child {
+      font-family: Helvetica Neue;
+      font-style: normal;
+      font-weight: 500;
+      font-size: 10px;
+      line-height: 12px;
+      letter-spacing: 0.09em;
+      text-decoration: none;
+      color: $light-gray;
+      cursor: pointer;
+      padding-bottom: 3px;
+
+      &:hover {
+        border-bottom: 3px solid darken($purple, 17%);
+      }
+    }
+
+    .active {
+      border-bottom: 3px solid $purple;
+    }
+  }
+  
   .controls {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Create see recently played link on media player. Although the other header links didn't have this, I added a hover transform to the new link according to the figma mock.